### PR TITLE
Prevent bad build plans on older GHCs by expressing dependence on TypeInType

### DIFF
--- a/type-level-sets.cabal
+++ b/type-level-sets.cabal
@@ -80,6 +80,7 @@ source-repository head
 
 library
   hs-source-dirs:       src
+  other-extensions:     TypeInType
 
 
   exposed-modules:      Data.Type.Set


### PR DESCRIPTION
This will prevent bad build plans on GHC < 8
As a hackage trustee, I have made a revision to this effect on 0.8.9.0