### PR TITLE
Added lookp to Data.Type.Set

### DIFF
--- a/src/Data/Type/Set.hs
+++ b/src/Data/Type/Set.hs
@@ -217,16 +217,23 @@ instance Conder False where
 
 type family Cmp (a :: k) (b :: k) :: Ordering
 
-{-| Membership of an element in a set, with an acommanying
-    value-level function that returns a bool -}
+{-| Membership of an element in a set, with an accompanying
+    value-level functions, one which returns a bool, and
+    one which returns the corresponding element -}
 class Member a s where
   member :: Proxy a -> Set s -> Bool
+
+  lookp :: Proxy a -> Set s -> a
 
 instance {-# OVERLAPS #-} Member a (a ': s) where
   member _ (Ext x _) = True
 
+  lookp _ (Ext x _) = x
+
 instance {-# OVERLAPPABLE #-} Member a s => Member a (b ': s) where
   member a (Ext _ xs) = member a xs
+
+  lookp a (Ext _ xs) = lookp a xs
 
 type family MemberP a s :: Bool where
             MemberP a '[]      = False


### PR DESCRIPTION
Firstly, thanks a lot for creating this library. I thought it would be nice to have a set value look-up function, so I've added `lookp` to `Data.Type.Set`. I copied the name from from `Data.Type.Map`.

Just a couple of questions:

1. Is there a reason why it is `lookp` and not `lookup`?
2. Isn't the `member` function vacuous, given that it must always return `True`, and that calling it is invalid if `Member`ship is not satisfied?