### PR TITLE
Added instance of Ord to Set.

### DIFF
--- a/src/Data/Type/Set.hs
+++ b/src/Data/Type/Set.hs
@@ -35,9 +35,20 @@ instance Show' (Set '[]) where
 instance (Show' (Set s), Show e) => Show' (Set (e ': s)) where
     show' (Ext e s) = ", " ++ show e ++ (show' s)
 
+instance Eq (Set '[]) where
+  (==) _ _ = True
 instance (Eq e, Eq (Set s)) => Eq (Set (e ': s)) where
     (Ext e m) == (Ext e' m') = e == e' && m == m'
 
+instance Ord (Set '[]) where
+  compare _ _ = EQ
+instance (Ord a, Ord (Set s)) => Ord (Set (a ': s)) where
+  compare (Ext a as) (Ext a' as') = case compare a a' of
+    EQ ->
+      compare as as'
+
+    other ->
+      other
 
 {-| At the type level, normalise the list form to the set form -}
 type AsSet s = Nub (Sort s)


### PR DESCRIPTION
What do you think about this Ord instance for Set? 

By the way, I've found an alternative to the stable quicksort change. I have added a function to Nubable (not in this PR) called collectNubs, which collects a list of all alternatives of Type.Set (Nub types) for a set Type.Set types. Do you think this is worth adding Data.Type.Set, or is it too specialised?