### PR TITLE
Add kind signature in SetProperties

### DIFF
--- a/src/Data/Type/Set.hs
+++ b/src/Data/Type/Set.hs
@@ -61,11 +61,16 @@ asSet x = nub (quicksort x)
 type IsSet s = (s ~ Nub (Sort s))
 
 {-| Useful properties to be able to refer to someties -}
-type SetProperties f = (Union f '[] ~ f, Split f '[] f,
-                        Union '[] f ~ f, Split '[] f f,
-                        Union f f ~ f, Split f f f,
-                        Unionable f '[], Unionable '[] f)
-
+type SetProperties (f :: [k]) =
+  ( Union f ('[] :: [k]) ~ f,
+    Split f ('[] :: [k]) f,
+    Union ('[] :: [k]) f ~ f,
+    Split ('[] :: [k]) f f,
+    Union f f ~ f,
+    Split f f f,
+    Unionable f ('[] :: [k]),
+    Unionable ('[] :: [k]) f
+  )
 {-- Union --}
 
 {-| Union of sets -}


### PR DESCRIPTION
GHC 9.2 complains about the `SetProperties` type synonym with 
```
src/Data/Type/Set.hs:64:1: error:
    • Uninferrable type variables k0, k1 in
      the type synonym right-hand side:
      ((Union @{k} f ('[] @k) :: [k]) ~ (f :: [k]),
       Split @{k} @{k0} @{k} f ('[] @k0) f,
       (Union @{k} ('[] @k) f :: [k]) ~ (f :: [k]),
       Split @{k1} @{k} @{k} ('[] @k1) f f,
       (Union @{k} f f :: [k]) ~ (f :: [k]), Split @{k} @{k} @{k} f f f,
       Unionable @{k} f ('[] @k), Unionable @{k} ('[] @k) f)
    • In the type declaration for ‘SetProperties’
   |
64 | type SetProperties f = (Union f '[] ~ f, Split f '[] f,
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^...
```

Adding the kind signature `type SetProperties (f :: [k]) = (Union f ('[] :: [k]), ...)` satisfies the type checker and is backwards compatible with earlier versions that apparently could infer the kind. It seems to be related to the third bullet under https://ghc.gitlab.haskell.org/ghc/doc/users_guide/9.2.1-notes.html#language
> Kind inference for data/newtype instance declarations is slightly more restrictive than before. In particular, GHC now requires that the kind of a data family instance be fully determined by the header of the instance, without looking at the definition of the constructor.