### PR TITLE
Fix tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .stack-work
+.dist-newstyle

--- a/examples/Example.hs
+++ b/examples/Example.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE DataKinds, TypeOperators, TypeFamilies, MultiParamTypeClasses #-}
 
-module Examples.Example where
+module Example where
 
 import GHC.TypeLits
 import Data.Type.Map

--- a/examples/Example2.hs
+++ b/examples/Example2.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DataKinds, TypeOperators, TypeFamilies, GADTs, StandaloneDeriving #-}
 {-# LANGUAGE FlexibleContexts #-}
 
-module Examples.Example2 where
+module Example2 where
 
 import GHC.TypeLits
 import Data.Type.Set

--- a/tests/hspec/MapSpec.hs
+++ b/tests/hspec/MapSpec.hs
@@ -5,8 +5,8 @@
 module MapSpec where
 
 import Test.Hspec
-import Examples.Example
-import Examples.Example2
+import Example
+import Example2
 
 import Data.Type.Map
 
@@ -18,7 +18,7 @@ spec :: Spec
 spec = do
   describe "Map tests" $
     it "Map tests" $ do
-      (lookp (Var @"x") Examples.Example.foo)  `shouldBe` (2 :: Int)
-      (lookp (Var @"w") Examples.Example.foo)  `shouldBe` (5 :: Int)
-      (lookp (Var @"z") Examples.Example.foo)  `shouldBe` True
-      (mapLength Examples.Example.foo) `shouldBe` 3
+      (lookp (Var @"x") Example.foo)  `shouldBe` (2 :: Int)
+      (lookp (Var @"w") Example.foo)  `shouldBe` (5 :: Int)
+      (lookp (Var @"z") Example.foo)  `shouldBe` True
+      (mapLength Example.foo) `shouldBe` 3

--- a/type-level-sets.cabal
+++ b/type-level-sets.cabal
@@ -71,7 +71,7 @@ build-type:             Simple
 cabal-version:          >= 1.10
 tested-with:            GHC >= 8.2.2
 
-extra-source-files:     examples/Example.hs, examples/Example2.hs, tests/hspec/MapSpec.hs, tests/hspec/Spec.hs, changelog.md
+extra-source-files:     changelog.md
 
 
 source-repository head
@@ -92,10 +92,10 @@ library
 test-suite tests
   type: exitcode-stdio-1.0
   main-is: Spec.hs
-  hs-source-dirs: ., tests/hspec
+  hs-source-dirs: examples, tests/hspec
   other-modules:
-    Examples.Example
-    Examples.Example2
+    Example
+    Example2
     MapSpec
   build-depends:
       type-level-sets


### PR DESCRIPTION
On main, `stack build --test` fails with 
```
Warning: File listed in type-level-sets.cabal file does not exist:
         examples/Example.hs

Warning: File listed in type-level-sets.cabal file does not exist:
         examples/Example2.hs
type-level-sets-0.8.10.0: unregistering (local file changes: examples/Example.hs examples/Example2.hs tests/hspec/MapSpec.hs tests/hspec/Spec.hs type-level-se...)
type-level-sets> build (lib + test)
Preprocessing library for type-level-sets-0.8.10.0..
Building library for type-level-sets-0.8.10.0..
Preprocessing test suite 'tests' for type-level-sets-0.8.10.0..
Cabal-simple_mPHDZzAJ_3.2.1.0_ghc-8.10.7: can't find source for
Examples/Example in ., tests/hspec,
.stack-work/dist/x86_64-linux/Cabal-3.2.1.0/build/tests/autogen,
.stack-work/dist/x86_64-linux/Cabal-3.2.1.0/build/global-autogen


Warning: File listed in type-level-sets.cabal file does not exist:
         examples/Example.hs

Warning: File listed in type-level-sets.cabal file does not exist:
         examples/Example2.hs
Progress 1/2

--  While building package type-level-sets-0.8.10.0 (scroll up to its section to see the error) using:
      /home/joseph/.stack/setup-exe-cache/x86_64-linux/Cabal-simple_mPHDZzAJ_3.2.1.0_ghc-8.10.7 --builddir=.stack-work/dist/x86_64-linux/Cabal-3.2.1.0 build lib:type-level-sets test:tests --ghc-options ""
```
This just fixes up the module hierarchy so stack can find everything properly.