### PR TITLE
Remove non-lazy If from Filter implementation

### DIFF
--- a/examples/ExampleSet2.hs
+++ b/examples/ExampleSet2.hs
@@ -17,6 +17,9 @@ data Natural (a :: Nat) where
 
 deriving instance Show (Natural n)
 
+instance Eq (Natural n) where
+    _ == _ = True
+
 foo :: Set '[String, Natural 1]
 foo = asSet $ Ext "str1" $ Ext (S Z) Empty
 
@@ -43,3 +46,29 @@ fooHasNat1 = member (Proxy :: Proxy (Natural 1)) foo
 
 barHasNat1 :: Bool
 barHasNat1 = member (Proxy :: Proxy (Natural 1)) bar
+
+r0_9 :: Set '[Natural 0, Natural 1, Natural 2, Natural 3, Natural 4, Natural 5, Natural 6, Natural 7, Natural 8, Natural 9]
+r0_9 =
+  Ext Z $
+  Ext (S Z) $
+  Ext (S (S Z)) $
+  Ext (S (S (S Z))) $
+  Ext (S (S (S (S Z)))) $
+  Ext (S (S (S (S (S Z))))) $
+  Ext (S (S (S (S (S (S Z)))))) $
+  Ext (S (S (S (S (S (S (S Z))))))) $
+  Ext (S (S (S (S (S (S (S (S Z)))))))) $
+  Ext (S (S (S (S (S (S (S (S (S Z))))))))) Empty
+
+r10_19 :: Set '[Natural 10, Natural 11, Natural 12, Natural 13, Natural 14, Natural 15, Natural 16, Natural 17, Natural 18, Natural 19]
+r10_19 =
+  Ext ((S . S . S . S . S . S . S . S . S . S) Z) $
+  Ext ((S . S . S . S . S . S . S . S . S . S . S) Z) $
+  Ext ((S . S . S . S . S . S . S . S . S . S . S . S) Z) $
+  Ext ((S . S . S . S . S . S . S . S . S . S . S . S . S) Z) $
+  Ext ((S . S . S . S . S . S . S . S . S . S . S . S . S . S) Z) $
+  Ext ((S . S . S . S . S . S . S . S . S . S . S . S . S . S . S) Z) $
+  Ext ((S . S . S . S . S . S . S . S . S . S . S . S . S . S . S . S) Z) $
+  Ext ((S . S . S . S . S . S . S . S . S . S . S . S . S . S . S . S . S) Z) $
+  Ext ((S . S . S . S . S . S . S . S . S . S . S . S . S . S . S . S . S . S) Z) $
+  Ext ((S . S . S . S . S . S . S . S . S . S . S . S . S . S . S . S . S . S . S) Z) Empty

--- a/tests/hspec/SetSpec.hs
+++ b/tests/hspec/SetSpec.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_GHC -fno-pre-inlining #-}
 
 module SetSpec where
 
@@ -17,3 +18,5 @@ spec = do
       barfooStr `shouldBe` "str1"
     it "Assert non-membership of a type not in a set at runtime" $ do
       barHasNat1 `shouldBe` False
+    it "Union of large sets should run in reasonable time" $ do
+      (r0_9 `union` r10_19) `shouldBe` (r0_9 `append` r10_19)


### PR DESCRIPTION
Addresses #17. Moving the `Filter` branching to top level type family patterns does appear to recover linear runtime. A rudimentary benchmark compiling the `hitmen` executable from https://github.com/jmorag/databass on my machine.
```
# current main
cabal run hitmen > b340c822bc25e75d81114327dd9a9161943d9111-out.txt  111.82s user 5.57s system 96% cpu 2:01.38 total
# with the new filter
cabal run hitmen > 1617525181eb4214ea9b65343af4351e5c07d9f5-out.txt  22.38s user 1.09s system 93% cpu 25.175 total
```